### PR TITLE
Npe on bad app

### DIFF
--- a/src/main/java/org/opengis/cite/gpkg10/core/SQLiteContainerTests.java
+++ b/src/main/java/org/opengis/cite/gpkg10/core/SQLiteContainerTests.java
@@ -96,7 +96,7 @@ public class SQLiteContainerTests extends CommonFixture {
     @Test(description = "See OGC 12-128r12: Requirement 3")
     public void filenameExtension() {
         final String fileName = this.gpkgFile.getName();
-        final String suffix = fileName.substring(fileName.indexOf('.'));
+        final String suffix = fileName.substring(fileName.lastIndexOf('.'));
         assertEquals(suffix, GPKG10.GPKG_FILENAME_SUFFIX,
                 ErrorMessage.format(ErrorMessageKeys.INVALID_SUFFIX, suffix));
     }

--- a/src/main/java/org/opengis/cite/gpkg10/core/SQLiteContainerTests.java
+++ b/src/main/java/org/opengis/cite/gpkg10/core/SQLiteContainerTests.java
@@ -62,7 +62,7 @@ public class SQLiteContainerTests extends CommonFixture {
     }
 
     /**
-     * A GeoPackage shall contain 0x47503130 ("GP10" in UTF-8/ASCII) in the
+     * A GeoPackage shall contain 0x47503130 ("GP10" in UTF-8/ASCII, [71,80,49,48]) in the
      * "Application ID" field of the database header. The field is located at
      * offset 64 (a 32-bit unsigned big-endian integer).
      *
@@ -84,7 +84,7 @@ public class SQLiteContainerTests extends CommonFixture {
         }
         final byte[] appID = Arrays.copyOfRange(headerBytes, GPKG10.APP_ID_OFFSET, GPKG10.APP_ID_OFFSET + 4);
         assertEquals(appID, GPKG10.APP_GP10,
-                ErrorMessage.format(ErrorMessageKeys.UNKNOWN_APP_ID, new String(appID, StandardCharsets.US_ASCII)));
+                ErrorMessage.format(ErrorMessageKeys.UNKNOWN_APP_ID, Arrays.toString(appID)));
     }
 
     /**


### PR DESCRIPTION
fix for #13, unicode 0 values has no ascii equivalent, so instead we are just output the actual byte values as an array, updated the comment to show correct values as well. 
