### PR TITLE
Sqlite column types case sensitive

### DIFF
--- a/src/main/java/org/opengis/cite/gpkg10/core/DataContentsTests.java
+++ b/src/main/java/org/opengis/cite/gpkg10/core/DataContentsTests.java
@@ -75,9 +75,9 @@ public class DataContentsTests extends CommonFixture
                         while(pragmaTableInfo.next())
                         {
                             final String dataType = pragmaTableInfo.getString("type");
-                            final boolean correctDataType = ALLOWED_SQL_TYPES.contains(dataType) ||
-                                                            TEXT_TYPE.matcher(dataType).matches() ||
-                                                            BLOB_TYPE.matcher(dataType).matches();
+                            final boolean correctDataType = ALLOWED_SQL_TYPES.contains(dataType.toUpperCase()) ||
+                                                            TEXT_TYPE.matcher(dataType.toUpperCase()).matches() ||
+                                                            BLOB_TYPE.matcher(dataType.toUpperCase()).matches();
 
                             assertTrue(correctDataType,
                                        ErrorMessage.format(ErrorMessageKeys.INVALID_DATA_TYPE,


### PR DESCRIPTION
previously, the column types had to be an EXACT match for those listed in the spec. sqlite generally doesn't enforce case sensitivity in column types, so we relaxed the check to pass for different case-ness. fix for #19 
