### PR TITLE
Make Tile schema test match 12-128r12 Table 11

### DIFF
--- a/src/main/java/org/opengis/cite/gpkg10/tiles/TileTests.java
+++ b/src/main/java/org/opengis/cite/gpkg10/tiles/TileTests.java
@@ -874,7 +874,7 @@ public class TileTests extends CommonFixture
     {
         final Map<String, ColumnDefinition> expectedColumns = new HashMap<>();
 
-        expectedColumns.put("id",          new ColumnDefinition("INTEGER", false, true,  true,  null));
+        expectedColumns.put("id",          new ColumnDefinition("INTEGER", true,  true,  true,  null));
         expectedColumns.put("zoom_level",  new ColumnDefinition("INTEGER", true,  false, false, null));
         expectedColumns.put("tile_column", new ColumnDefinition("INTEGER", true,  false, false, null));
         expectedColumns.put("tile_row",    new ColumnDefinition("INTEGER", true,  false, false, null));


### PR DESCRIPTION
The second argument to a ColumnDefinition is `notNull`. Table 11 shows that no columns are allowed to be null in the tiles matrix, so it should be true (i.e. not null) for `id` as it is for other columns..